### PR TITLE
Refactor ReactiveTimedAspect to use MeterRegistryService and add reac…

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ monitoring capabilities.
 <dependency>
     <groupId>box.tapsi.libs</groupId>
     <artifactId>metrics-core</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
 </dependency>
 ```
 
@@ -150,6 +150,8 @@ logging:
 - `recordTimer(meterName: MeterName, time: Long, tags: List<Tag>)`
 - `registerGauge(meterName: MeterName, tags: List<Tag>, obj: T, valueFunction: (T) -> Double)`
 - `distributionSummary(meterName: MeterName, tags: List<Tag>, value: Double, baseUnit: String?)`
+- `tap(mono: Mono<T>): Mono<T>`
+- `tap(flux: Flux<T>): Flux<T>`
 
 ### ReactiveTimed Annotation
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "box.tapsi.libs"
-version = "1.0.3"
+version = "1.0.4"
 description = "metrics-core"
 
 java {

--- a/src/main/kotlin/box/tapsi/libs/metrics/core/aop/ReactiveTimedAspect.kt
+++ b/src/main/kotlin/box/tapsi/libs/metrics/core/aop/ReactiveTimedAspect.kt
@@ -2,7 +2,7 @@ package box.tapsi.libs.metrics.core.aop
 
 import box.tapsi.libs.metrics.core.TapsiMetricProperties
 import box.tapsi.libs.metrics.core.annotations.ReactiveTimed
-import io.micrometer.observation.ObservationRegistry
+import box.tapsi.libs.metrics.core.services.MeterRegistryService
 import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.annotation.Around
 import org.aspectj.lang.annotation.Aspect
@@ -12,7 +12,6 @@ import org.springframework.core.Ordered
 import org.springframework.core.annotation.AnnotationUtils
 import org.springframework.stereotype.Component
 import reactor.core.CorePublisher
-import reactor.core.observability.micrometer.Micrometer
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import java.lang.reflect.Method
@@ -38,7 +37,7 @@ import java.lang.reflect.Method
 @Aspect
 @Component
 class ReactiveTimedAspect(
-  private val observationRegistry: ObservationRegistry,
+  private val meterRegistryService: MeterRegistryService,
   private val tapsiMetricProperties: TapsiMetricProperties,
 ) : Ordered {
   val defaultMetricName = "reactive.method.timed"
@@ -110,7 +109,7 @@ class ReactiveTimedAspect(
       for (tag in tags) {
         unRecordedResult = unRecordedResult.tag(tag.key, tag.value)
       }
-      (unRecordedResult as Mono<Any>).contextCapture().tap(Micrometer.observation(observationRegistry))
+      (unRecordedResult as Mono<Any>).`as`(meterRegistryService::tap)
     }
 
     is Flux<*> -> {
@@ -119,7 +118,7 @@ class ReactiveTimedAspect(
       for (tag in tags) {
         unRecordedResult = unRecordedResult.tag(tag.key, tag.value)
       }
-      (unRecordedResult as Flux<Any>).contextCapture().tap(Micrometer.observation(observationRegistry))
+      (unRecordedResult as Flux<Any>).`as`(meterRegistryService::tap)
     }
 
     else -> result

--- a/src/main/kotlin/box/tapsi/libs/metrics/core/autoconfigure/TapsiMetricsAutoConfiguration.kt
+++ b/src/main/kotlin/box/tapsi/libs/metrics/core/autoconfigure/TapsiMetricsAutoConfiguration.kt
@@ -35,5 +35,8 @@ class TapsiMetricsAutoConfiguration {
   @ConditionalOnMissingBean(MeterRegistryService::class)
   @ConditionalOnBean(MeterRegistry::class)
   @Bean
-  fun meterRegistryService(meterRegistry: MeterRegistry): MeterRegistryService = MeterRegistryServiceImpl(meterRegistry)
+  fun meterRegistryService(
+    meterRegistry: MeterRegistry,
+    observationRegistry: ObservationRegistry,
+  ): MeterRegistryService = MeterRegistryServiceImpl(meterRegistry, observationRegistry)
 }

--- a/src/main/kotlin/box/tapsi/libs/metrics/core/services/MeterRegistryService.kt
+++ b/src/main/kotlin/box/tapsi/libs/metrics/core/services/MeterRegistryService.kt
@@ -3,6 +3,7 @@ package box.tapsi.libs.metrics.core.services
 import box.tapsi.libs.metrics.core.MeterName
 import io.micrometer.core.instrument.Meter
 import io.micrometer.core.instrument.Tag
+import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import kotlin.reflect.KClass
 
@@ -70,4 +71,20 @@ interface MeterRegistryService {
    * @param baseUnit The base unit of measurement for the metric, or null if no base unit is specified.
    */
   fun distributionSummary(meterName: MeterName, tags: List<Tag>, value: Double, baseUnit: String?)
+
+  /**
+   * Enhances the provided Mono by applying reactive observation capabilities, such as metrics or tracing.
+   *
+   * @param mono The Mono instance to be tapped for observation enhancements.
+   * @return A Mono instance with observation capabilities applied.
+   */
+  fun <T : Any> tap(mono: Mono<T>): Mono<T>
+
+  /**
+   * Enhances the provided Flux by applying reactive observation capabilities, such as metrics or tracing.
+   *
+   * @param flux The Flux instance to be tapped for observation enhancements.
+   * @return A Flux instance with observation capabilities applied.
+   */
+  fun <T : Any> tap(flux: Flux<T>): Flux<T>
 }

--- a/src/test/kotlin/box/tapsi/libs/metrics/core/aop/ReactiveTimedAspectTest.kt
+++ b/src/test/kotlin/box/tapsi/libs/metrics/core/aop/ReactiveTimedAspectTest.kt
@@ -2,7 +2,7 @@ package box.tapsi.libs.metrics.core.aop
 
 import box.tapsi.libs.metrics.core.TapsiMetricProperties
 import box.tapsi.libs.metrics.core.annotations.ReactiveTimed
-import io.micrometer.observation.ObservationRegistry
+import box.tapsi.libs.metrics.core.services.MeterRegistryService
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Answers
@@ -17,7 +17,7 @@ import reactor.test.StepVerifier
 class ReactiveTimedAspectTest {
 
   @Mock
-  private lateinit var observationRegistry: ObservationRegistry
+  private lateinit var meterRegistryService: MeterRegistryService
 
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
   private lateinit var tapsiMetricProperties: TapsiMetricProperties
@@ -40,7 +40,7 @@ class ReactiveTimedAspectTest {
     Mockito.`when`(reactiveTimedProperties.defaultTags).thenReturn(emptyMap())
 
     // Create the aspect
-    reactiveTimedAspect = ReactiveTimedAspect(observationRegistry, tapsiMetricProperties)
+    reactiveTimedAspect = ReactiveTimedAspect(meterRegistryService, tapsiMetricProperties)
 
     // Create the target service and proxy with the aspect
     val testService = TestService()


### PR DESCRIPTION
…tive tap support

- Replaced `ObservationRegistry` with `MeterRegistryService` in `ReactiveTimedAspect`.
- Enhanced `MeterRegistryService` with reactive `tap` methods for `Mono` and `Flux`.
- Adjusted `TapsiMetricsAutoConfiguration` to inject `ObservationRegistry` into `MeterRegistryServiceImpl`.
- Updated version to `1.0.4` in `build.gradle.kts` and `README.md`.
- Added related unit test updates and documentation changes.